### PR TITLE
[Minor] Change class field for actor/ship/creature sheet token image

### DIFF
--- a/css/mosh.css
+++ b/css/mosh.css
@@ -833,7 +833,7 @@
   display: inline-flex;
 }
 
-.mosh .moshlogo {
+.mosh .profile {
   width: 140px;
   height: auto;
   border: 0;

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -12,8 +12,7 @@
           from 1 to 12 and will create that number of columns.  --}}
 
       <div class="header">
-        <!-- <img class="moshlogo" src="https://images.squarespace-cdn.com/content/5e97675644a24d569352fe17/1587070346832-RKM533ZN7XN778HQEBUW/Mothership-M-Logo-White.png?content-type=image%2Fpng" data-i18n-title="Mothership Logo" title="[Mothership Logo]"> -->
-        <img class="moshlogo" src="{{img}}" data-edit="img" title="{{name}}" height="150"
+        <img class="profile" src="{{img}}" data-edit="img" title="{{name}}" height="150"
           width="150" />
 
         <div class="headergrid">

--- a/templates/actor/creature-sheet.html
+++ b/templates/actor/creature-sheet.html
@@ -127,7 +127,7 @@
       {{editor content=data.description target="data.description" button=true owner=owner editable=true}}
     </div>
     <div class="creature-abilities">
-      <img class="img noborder" src="{{img}}" data-edit="img" title="{{name}}" height="auto" width="100%" />
+      <img class="img profile noborder" src="{{img}}" data-edit="img" title="{{name}}" style="height:auto; width:100%;" />
       <div class="creature-ability-container creature-ability-title">Special Abilities</div>
       <div class="whiteline"></div>
       {{#each abilities as |ability id|}}

--- a/templates/actor/ship-sheet.html
+++ b/templates/actor/ship-sheet.html
@@ -2,9 +2,7 @@
 
     {{!-- Sheet Header --}}
     <div class="header">
-        <!-- <img class="moshlogo" src="https://images.squarespace-cdn.com/content/5e97675644a24d569352fe17/1587070346832-RKM533ZN7XN778HQEBUW/Mothership-M-Logo-White.png?content-type=image%2Fpng" data-i18n-title="Mothership Logo" title="[Mothership Logo]"> -->
-        <img class="moshlogo" src="{{img}}" data-edit="img" title="{{name}}" height="150"
-            width="150" />
+        <img class="profile" src="{{img}}" data-edit="img" title="{{name}}" height="150" width="150" />
 
         <div class="headergrid" style="grid-template-columns: 1fr 1fr 1fr; padding: 1em;">
             <!-- <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" height="150" width="150"/> -->


### PR DESCRIPTION
VTTA Tokenizer expects [one of four specific CSS class fields](https://github.com/MrPrimate/vtta-tokenizer/blob/master/src/hooks.js#L171) in order to
properly register the Tokenizer UI with the Actor sheet image upload
button. This commit changes the existing class `moshlogo` to `profile`
in order to enable VTTA Tokenizer support.

