### PR TITLE
JSON Importer: Weapon name's clarity improvement + fix

### DIFF
--- a/module/mosh.js
+++ b/module/mosh.js
@@ -518,7 +518,7 @@ async function createActorFromJson(jsonData) {
     for (let i = 0; i < actorData.weapons.length; i++) {
       console.log(actorData.weapons[i]);
       items.push({
-        "name": actorData.weapons[i].name,
+        "name":  actorData.weapons[i].name ? actorData.weapons[i].name + " " + actorData.weapons[i].weaponType : actorData.weapons[i].weaponType,
         "type": "weapon",
         "system": {
           "description": actorData.weapons[i].special,


### PR DESCRIPTION
The current code only takes into account the weapon's names, which for example for the Revolver is FN Slug, I've found myself repeatedly looking back to the book to check which that one was, this change concatenates the `name` with the `weaponType`, having both the flavor and the usefulness, following the formatting order seen on the PSG.

On top of that, it fixes an issue where weapons with the `name` left blank would not be added, I guess these weapons are the ones that are on the weapon's table but not on the little spread on pg 12 and 13 of the PSG (such as scalpel and boarding axe as some examples)

I know that line is horribly long, anyone should feel free to edit it into sense if needed, tried it on my Foundry instance and it worked as intended, even importing weapons that it'd previously not import