### PR TITLE
Fix #39: gridDistance warnings on v12

### DIFF
--- a/system.json
+++ b/system.json
@@ -127,6 +127,10 @@
       "flags": {}
     }
   ],
+  "grid": {
+    "distance": 1,
+    "units": "meter"
+  },
   "gridDistance": 1,
   "gridUnits": "meter",
   "primaryTokenAttribute": "health",


### PR DESCRIPTION
Foundry v12 add a deprecation warning for gridDistance and gridUnits in system.json. v11 doesn't support the new syntax, so to maintain backwards compatibility define using both the old way and the new way, since v11 doesn't complain at all about tags but doesn't understand. This is the suggested way of addressing the issue while maintaining v11 support according to the Foundry VTT discord.

Once support for v11 (and previous versions) is dropped the gridDistance and gridUnits keys can be removed.