### PR TITLE
fix: add media query for mobile to prevent overlap on character sheet

### DIFF
--- a/css/mosh.css
+++ b/css/mosh.css
@@ -363,6 +363,9 @@ p {
 
 .mosh .stress {grid-area: stress;}
 .mosh .health {grid-area: centercol;}
+@media screen and (max-width: 660px) {
+  .mosh .health {grid-area: 3 / 1 / 3 / 4;}
+}
 .mosh .healthspread {width:96%;}
 
 .mosh .char-header h1.charname {


### PR DESCRIPTION
I would like for my players to be able to use the character sheets from their phone. Currently the health, wounds, stress, armor, and trauma response do not have enough room to be displayed properly. I thought it made sense to move that content below stats and saves if there is not enough room to display them without overlapping.

## Before

![before](https://github.com/user-attachments/assets/f81adc03-a974-4d2d-aab4-6976771db16a)

## After

![after](https://github.com/user-attachments/assets/d4cbd00b-757d-4e85-ade3-116f652d0788)
