### PR TITLE
0.5.25.1 hotfix

### DIFF
--- a/module/item/class-sheet.js
+++ b/module/item/class-sheet.js
@@ -101,9 +101,9 @@ export class MothershipClassSheet extends MothershipItemSheet {
         return this.render(false);
       }
       else if(event.currentTarget.id =="choose_skill_or_li"){
-        const li = $(ev.currentTarget);
+        const li = $(event.currentTarget);
         let index = li.data("itemId");
-        const parent = $(ev.currentTarget).parents(".items-list");
+        const parent = $(event.currentTarget).parents(".items-list");
         let parent_index = parent.data("itemId");
 
         let options = this.object.system.selected_adjustment.choose_skill_or;
@@ -188,16 +188,17 @@ export class MothershipClassSheet extends MothershipItemSheet {
 
     html.find('.skills-group-option-createnew').click(ev => {
       const li = $(ev.currentTarget).parents(".item");
-    
+      const index = li[0].attributes["data-item-id"].value;
+	  
       let new_data = {
-        "name":li.find('input[name="choose_skill_or_name"]').prop("value"),
-        "trained": li.find('input[name="choose_skill_or_trained"]').prop("value"),
-        "expert": li.find('input[name="choose_skill_or_expert"]').prop("value"),
-        "expert_full_set": li.find('input[name="choose_skill_or_expert_full_set"]').prop("value"),
-        "master": li.find('input[name="choose_skill_or_master"]').prop("value"),
-        "master_full_set": li.find('input[name="choose_skill_or_master_full_set"]').prop("value"),
+        "name":li.find('input[name="choose_skill_or_name"]')[index].value,
+        "trained": li.find('input[name="choose_skill_or_trained"]')[index].value,
+        "expert": li.find('input[name="choose_skill_or_expert"]')[index].value,
+        "expert_full_set": li.find('input[name="choose_skill_or_expert_full_set"]')[index].value,
+        "master": li.find('input[name="choose_skill_or_master"]')[index].value,
+        "master_full_set": li.find('input[name="choose_skill_or_master_full_set"]')[index].value,
         "from_list": [],
-    }
+      }
       if(new_data.name ==""){
         new_data.name = `Option: ${(this.object.system.selected_adjustment.choose_skill_or[li.data("itemId")].length)+1}`
       }
@@ -224,12 +225,12 @@ export class MothershipClassSheet extends MothershipItemSheet {
       this.object.update({"system.selected_adjustment.choose_skill_or":options});
 
       //clear form and hide it
-      li.find('input[name="choose_skill_or_name"]').prop("value","");
-      li.find('input[name="choose_skill_or_trained"]').prop("value","");
-      li.find('input[name="choose_skill_or_expert"]').prop("value","");
-      li.find('input[name="choose_skill_or_expert_full_set"]').prop("value","");
-      li.find('input[name="choose_skill_or_master"]').prop("value","");
-      li.find('input[name="choose_skill_or_master_full_set"]').prop("value","");
+      li.find('input[name="choose_skill_or_name"]')[index].value = "";
+      li.find('input[name="choose_skill_or_trained"]')[index].value = "";
+      li.find('input[name="choose_skill_or_expert"]')[index].value = "";
+      li.find('input[name="choose_skill_or_expert_full_set"]')[index].value = "";
+      li.find('input[name="choose_skill_or_master"]')[index].value = "";
+      li.find('input[name="choose_skill_or_master_full_set"]')[index].value = "";
 
       return this.render(false);
     });

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "mosh",
   "title": "MoSh - Unofficial Mothership",
   "description": "The unofficial Mothership system for FoundryVTT.",
-  "version": "0.5.25",
+  "version": "0.5.25.1",
   "esmodules": [
     "module/mosh.js"
   ],


### PR DESCRIPTION
Fixed bugs:
* When editing Optional Skills for a Class, dropping a Skill onto the saved row does nothing due to a copy-paste typo in the code.
* When entering new options for Optional Skills only first row of inputs in the first group is used.
Thanks to [ECXevian](https://github.com/ECXevian)