### PR TITLE
Add missing Major i18n entry

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1001,6 +1001,7 @@
     "Macros": "Macros",
     "MaintenanceAndRepairs": "Maintenance & Repairs",
     "MaintenanceCheck": "Maintenance Check",
+    "Major": "Major",
     "Maximum": "Maximum",
     "MaxShots": "Max Shots",
     "MaxO2": "Max. O2",


### PR DESCRIPTION
Just added a missing i18n Key - Value (`Mosh.Major`) related to ship repairs. 